### PR TITLE
fr: Fix 'Tap to draw' translation

### DIFF
--- a/assets/i18n/fr.po
+++ b/assets/i18n/fr.po
@@ -3898,7 +3898,7 @@ msgstr[0] "${ unspentXp } XP non dépensée"
 msgstr[1] "${ unspentXp } XP non dépensée"
 
 msgid "Tap to draw"
-msgstr "Appuyez ici pour révéler un pion"
+msgstr "Appuyer pour piocher"
 
 msgid "Draw another"
 msgstr "Révéler un autre pion"


### PR DESCRIPTION
The French translation explicitly mentions tokens, while the string can also be used when selecting random weaknesses, partners, ...
This commit removes the 'token' (pion) mention.