### PR TITLE
Fix: Correctly translate information header in Scarlet Keys dossiers

### DIFF
--- a/src/components/campaignguide/CampaignMapView.tsx
+++ b/src/components/campaignguide/CampaignMapView.tsx
@@ -836,7 +836,7 @@ function LocationContent({
         { !!dossier.length && status !== 'locked' && (
           <View>
             <View style={space.paddingBottomS}>
-              <CardDetailSectionHeader title={ngettext(msgid`Information`, `Information`, dossier.length)} />
+              <CardDetailSectionHeader title={t`Information`} />
             </View>
             { map(dossier, (entry, idx) => (
               <DossierComponent key={idx} dossier={entry} idx={idx} showCity={showCity} />


### PR DESCRIPTION
While checking the german translations in the scarlet keys campaign, I've noticed that the Information header in the dossiers was always showing up as "UNDEFINED". I can confirm that this was the case for the spanish and french translations as well.

As far as I understand, the translation function `ngettext` used before my change is dealing with plural forms. However, the "Information" header doesn't contain any pluralization which is why I've changed it to use `t`. This fixes the problem as far as I can see.