### PR TITLE
Feature/add tooltip encounter cards

### DIFF
--- a/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
+++ b/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
@@ -10,6 +10,7 @@ import { msgid, ngettext, t } from 'ttag';
 import { stringList } from '@lib/stringHelper';
 import SetupStepWrapper from '../SetupStepWrapper';
 import { BorderColor, EncounterSetsStep } from '@data/scenario/types';
+import EncounterIcon from '@icons/EncounterIcon';
 import { EncounterCardErrataProps } from '@components/campaignguide/EncounterCardErrataView';
 import CampaignGuideTextComponent from '../CampaignGuideTextComponent';
 import space from '@styles/space';
@@ -20,7 +21,6 @@ import ArkhamButton from '@components/core/ArkhamButton';
 import LanguageContext from '@lib/i18n/LanguageContext';
 import { useSettingValue } from '@components/core/hooks';
 import ToolTip from '@components/core/ToolTip';
-import EncounterIcon from '@icons/EncounterIcon';
 
 const CORE_SET_ICONS = new Set([
   'torch', 'arkham', 'cultists', 'tentacles', 'rats', 'ghouls', 'striking_fear',

--- a/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
+++ b/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
@@ -10,7 +10,6 @@ import { msgid, ngettext, t } from 'ttag';
 import { stringList } from '@lib/stringHelper';
 import SetupStepWrapper from '../SetupStepWrapper';
 import { BorderColor, EncounterSetsStep } from '@data/scenario/types';
-import EncounterIcon from '@icons/EncounterIcon';
 import { EncounterCardErrataProps } from '@components/campaignguide/EncounterCardErrataView';
 import CampaignGuideTextComponent from '../CampaignGuideTextComponent';
 import space from '@styles/space';
@@ -20,6 +19,8 @@ import { CampaignId } from '@actions/types';
 import ArkhamButton from '@components/core/ArkhamButton';
 import LanguageContext from '@lib/i18n/LanguageContext';
 import { useSettingValue } from '@components/core/hooks';
+import ToolTip from '@components/core/ToolTip';
+import EncounterIcon from '@icons/EncounterIcon';
 
 const CORE_SET_ICONS = new Set([
   'torch', 'arkham', 'cultists', 'tentacles', 'rats', 'ghouls', 'striking_fear',
@@ -88,11 +89,16 @@ export default function EncounterSetStepComponent({ componentId, color, campaign
           <View style={[styles.iconPile, space.marginTopM, space.marginBottomS]}>
             { map(encounterSets, set => !!set && (
               <View style={[space.marginSideS, space.marginBottomM]} key={set.code}>
-                <EncounterIcon
-                  encounter_code={set.code}
+                <ToolTip
                   size={48}
-                  color={CORE_SET_ICONS.has(set.code) ? colors.skill.combat.icon : colors.darkText}
-                />
+                  label={set.name}
+                >
+                  <EncounterIcon
+                      encounter_code={set.code}
+                      size={48}
+                      color={CORE_SET_ICONS.has(set.code) ? colors.skill.combat.icon : colors.darkText}
+                  />
+                </ToolTip>
               </View>
             )) }
           </View>

--- a/src/components/core/ToolTip.tsx
+++ b/src/components/core/ToolTip.tsx
@@ -1,0 +1,73 @@
+import { Text, TouchableOpacity, View } from "react-native";
+import React, { useState, useContext, ReactNode, useCallback } from "react";
+import StyleContext from "@styles/StyleContext";
+
+interface Props {
+  label: string | undefined;
+  size: number;
+  children: ReactNode;
+}
+export default function ToolTip({ label, size, children }: Props) {
+  const { colors } = useContext(StyleContext);
+  const [toggle, setToggle] = useState(false);
+
+  const handlePressIn = useCallback(() => {
+    setToggle(true);
+  }, []);
+
+  const handlePressOut = useCallback(() => {
+    setToggle(false);
+  }, []);
+
+  return (
+    <>
+      {toggle && (
+        <>
+          <View
+            style={{
+              position: "absolute",
+              backgroundColor: colors.background,
+              paddingVertical: 4,
+              paddingHorizontal: 5,
+              bottom: size,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flex: 1,
+              borderRadius: 10,
+              borderColor: colors.lightText,
+              borderWidth: 1,
+              left: -40,
+              right: -40,
+            }}
+          >
+            <Text style={{ color: colors.lightText, textAlign: "center" }}>
+              {label}
+            </Text>
+          </View>
+          <View
+            style={{
+              width: 0,
+              height: 0,
+              left: size / 2 - 7.5,
+              top: -4,
+              backgroundColor: "transparent",
+              borderStyle: "solid",
+              borderLeftWidth: 7.5,
+              borderRightWidth: 7.5,
+              borderBottomWidth: 6,
+              borderLeftColor: "transparent",
+              borderRightColor: "transparent",
+              borderBottomColor: colors.lightText,
+              position: "absolute",
+              transform: [{ rotate: "180deg" }],
+            }}
+          />
+        </>
+      )}
+      <TouchableOpacity onPressIn={handlePressIn} onPressOut={handlePressOut}>
+        {children}
+      </TouchableOpacity>
+    </>
+  );
+}

--- a/src/components/core/ToolTip.tsx
+++ b/src/components/core/ToolTip.tsx
@@ -8,7 +8,7 @@ interface Props {
   children: ReactNode;
 }
 export default function ToolTip({ label, size, children }: Props) {
-  const { colors } = useContext(StyleContext);
+  const { colors, typography } = useContext(StyleContext);
   const [toggle, setToggle] = useState(false);
 
   const handlePressIn = useCallback(() => {
@@ -27,8 +27,6 @@ export default function ToolTip({ label, size, children }: Props) {
             style={{
               position: "absolute",
               backgroundColor: colors.background,
-              paddingVertical: 4,
-              paddingHorizontal: 5,
               bottom: size,
               display: "flex",
               alignItems: "center",
@@ -37,11 +35,13 @@ export default function ToolTip({ label, size, children }: Props) {
               borderRadius: 10,
               borderColor: colors.lightText,
               borderWidth: 1,
+              paddingVertical: 4,
+              paddingHorizontal: 5,
               left: -40,
               right: -40,
             }}
           >
-            <Text style={{ color: colors.lightText, textAlign: "center" }}>
+            <Text style={[typography.small, typography.regular,  { textAlign: "center" }]}>
               {label}
             </Text>
           </View>


### PR DESCRIPTION
Like discussed, I wanted to add a tooltip feature for the encounter cards, because sometimes I can't really remember the icons. So I've added a Tooltip component for the encounter cards icon to show the user the actual encounter set name. It works as long as the user press, but it can be modified to adjust the behaviour desired.

Here's a photo of what it looks like in both theme:
![image](https://github.com/zzorba/ArkhamCards/assets/21199130/79bbc21a-186b-45e9-a646-1171e4cfc846)
![image](https://github.com/zzorba/ArkhamCards/assets/21199130/5cc915f3-f509-4a74-8cbb-c1fc69172edf)

