### PR TITLE
Add tooltip to location and fix tooltip visual bug

### DIFF
--- a/src/components/campaignguide/LocationSetupView/LocationCard.tsx
+++ b/src/components/campaignguide/LocationSetupView/LocationCard.tsx
@@ -9,6 +9,7 @@ import AppIcon from '@icons/AppIcon';
 import useSingleCard from '@components/card/useSingleCard';
 import LoadingSpinner from '@components/core/LoadingSpinner';
 import { LocationAnnotation } from '@data/scenario/types';
+import ToolTip from '@components/core/ToolTip';
 
 const PLAYER_BACK = require('../../../../assets/player-back.png');
 const ATLACH = require('../../../../assets/atlach.jpg');
@@ -59,13 +60,16 @@ function LocationCardImage({ code, back, name, rotate, rotateLeft, width, height
     );
   }
   return (
-    <FastImage
-      style={[styles.verticalCardImage, { width, height }, rotate ? { transform: [{ rotate: rotateLeft ? '-90deg' : '90deg' }] } : undefined]}
-      source={{
-        uri,
-      }}
-      resizeMode="contain"
-    />
+    <ToolTip label={(back && card.back_name) || card.name} height={height} width={width}>
+      <FastImage
+        style={[styles.verticalCardImage, { width, height }, rotate ? { transform: [{ rotate: rotateLeft ? '-90deg' : '90deg' }] } : undefined]}
+        source={{
+          uri,
+        }}
+        resizeMode="contain"
+      />
+    </ToolTip>
+   
   );
 }
 

--- a/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
+++ b/src/components/campaignguide/ScenarioStepComponent/EncounterSetStepComponent.tsx
@@ -90,7 +90,8 @@ export default function EncounterSetStepComponent({ componentId, color, campaign
             { map(encounterSets, set => !!set && (
               <View style={[space.marginSideS, space.marginBottomM]} key={set.code}>
                 <ToolTip
-                  size={48}
+                  height={48}
+                  width={48}
                   label={set.name}
                 >
                   <EncounterIcon

--- a/src/components/core/ToolTip.tsx
+++ b/src/components/core/ToolTip.tsx
@@ -4,10 +4,11 @@ import StyleContext from "@styles/StyleContext";
 
 interface Props {
   label: string | undefined;
-  size: number;
   children: ReactNode;
+  height: number;
+  width: number
 }
-export default function ToolTip({ label, size, children }: Props) {
+export default function ToolTip({ label, height, width, children }: Props) {
   const { colors, typography } = useContext(StyleContext);
   const [toggle, setToggle] = useState(false);
 
@@ -27,7 +28,7 @@ export default function ToolTip({ label, size, children }: Props) {
             style={{
               position: "absolute",
               backgroundColor: colors.background,
-              bottom: size,
+              bottom: height+5,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
@@ -49,8 +50,8 @@ export default function ToolTip({ label, size, children }: Props) {
             style={{
               width: 0,
               height: 0,
-              left: size / 2 - 7.5,
-              top: -4,
+              left: width / 2 - 7.5,
+              bottom: height,
               backgroundColor: "transparent",
               borderStyle: "solid",
               borderLeftWidth: 7.5,


### PR DESCRIPTION
I've added the tooltip to location with the current card name which help know what is the card name in other languages. I've also changed a little bit of the tooltip to make it works on the actual height we send. It shouldn't affect much of the dragging behaviour of the current location placement.

Here is what the tooltip looks on locations:

![image](https://github.com/zzorba/ArkhamCards/assets/21199130/dd759796-3061-4966-b875-6bb86666a3d9)
