### PR TITLE
[Feature Request] openURL for ${lang}.arkhamdb.com

### DIFF
--- a/src/components/card/DbCardDetailSwipeView.tsx
+++ b/src/components/card/DbCardDetailSwipeView.tsx
@@ -35,6 +35,7 @@ import CardCustomizationOptions from './CardDetailView/CardCustomizationOptions'
 import { useCardCustomizations, useParsedDeck, useSimpleDeckEdits } from '@components/deck/hooks';
 import { CustomizationChoice } from '@data/types/CustomizationOption';
 import LanguageContext from '@lib/i18n/LanguageContext';
+import { getArkhamDbDomain } from '@lib/i18n/LanguageProvider';
 import { getSystemLanguage } from '@lib/i18n';
 
 export interface CardDetailSwipeProps {
@@ -258,16 +259,8 @@ function DbCardDetailSwipeView(props: Props) {
   useNavigationButtonPressed(({ buttonId }) => {
     if (currentCard) {
       if (buttonId === 'share') {
-        useCallback(async () => {
-          const lang = getSystemLanguage();
-          const supportedLink = await Linking.canOpenURL(`https://${lang}.arkhamdb.com/card/${currentCard.code}#reviews-header`);
-          
-          if (supportedLink) {
-            Linking.openURL(`https://${lang}.arkhamdb.com/card/${currentCard.code}#reviews-header`);
-          } else {
-            Linking.openURL(`https://arkhamdb.com/card/${currentCard.code}#reviews-header`);
-          }
-        }, []);
+        const arkhamDbDomain = getArkhamDbDomain(getSystemLanguage());
+        Linking.openURL(`${arkhamDbDomain}/card/${currentCard.code}#reviews-header`);
       } else if (buttonId === 'deck') {
         showInvestigatorCards(currentCard.code);
       } else if (buttonId === 'faq') {

--- a/src/components/card/DbCardDetailSwipeView.tsx
+++ b/src/components/card/DbCardDetailSwipeView.tsx
@@ -35,6 +35,7 @@ import CardCustomizationOptions from './CardDetailView/CardCustomizationOptions'
 import { useCardCustomizations, useParsedDeck, useSimpleDeckEdits } from '@components/deck/hooks';
 import { CustomizationChoice } from '@data/types/CustomizationOption';
 import LanguageContext from '@lib/i18n/LanguageContext';
+import { getSystemLanguage } from '@lib/i18n';
 
 export interface CardDetailSwipeProps {
   cardCodes: string[];
@@ -257,7 +258,16 @@ function DbCardDetailSwipeView(props: Props) {
   useNavigationButtonPressed(({ buttonId }) => {
     if (currentCard) {
       if (buttonId === 'share') {
-        Linking.openURL(`https://arkhamdb.com/card/${currentCard.code}#reviews-header`);
+        useCallback(async () => {
+          const lang = getSystemLanguage();
+          const supportedLink = await Linking.canOpenURL(`https://${lang}.arkhamdb.com/card/${currentCard.code}#reviews-header`);
+          
+          if (supportedLink) {
+            Linking.openURL(`https://${lang}.arkhamdb.com/card/${currentCard.code}#reviews-header`);
+          } else {
+            Linking.openURL(`https://arkhamdb.com/card/${currentCard.code}#reviews-header`);
+          }
+        }, []);
       } else if (buttonId === 'deck') {
         showInvestigatorCards(currentCard.code);
       } else if (buttonId === 'faq') {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4732f7a3-abae-4141-96e1-4b9d23f5b9ac)

As you can see in the screenshot, when I tried to open the card on the ArkhamDB site, it always linked to the English original site.

To improve this, I've proposed the following PR, but this is a change I made without fully understanding all of the code, so feel free to ignore it completely and rewrite it to your liking.

Note that this PR has not been tested.

Thank you.