### PR TITLE
Saving deck dialog fix

### DIFF
--- a/src/components/deck/dialogs.tsx
+++ b/src/components/deck/dialogs.tsx
@@ -874,8 +874,8 @@ export function useSaveDialog(parsedDeckResults: ParsedDeckResults): DeckEditSta
             mode: 'view',
           },
         });
-        setSaving(false);
       }
+      setSaving(false);
     } catch(e) {
       handleSaveError(e);
     }


### PR DESCRIPTION
This PR fixes the bug when the saving dialog appears after a successful deck saving

Before that fix, the dialog appears when you switch back to the app.

As I get the problem, 
```
Navigation.dismissAllModals();
```

hides the dialog until you switch to some other app on your phone
Then, when you return to the app, the `saving` state will have more priority on dismissAllModals. And because this value still has a `true` value, this dialog appears again.

As I got this problem, you necessarily need to set the visible state to false in either case.
