### PR TITLE
Eldritch Brand card limit

### DIFF
--- a/src/lib/DeckValidation.ts
+++ b/src/lib/DeckValidation.ts
@@ -36,6 +36,7 @@ import {
   FORCED_LEARNING_CODE,
   PRECIOUS_MEMENTO_FORMER_CODE,
   PRECIOUS_MEMENTO_FUTURE_CODE,
+  ELDRITCH_BRAND_CODE,
 } from '@app_constants';
 import Card, { InvestigatorChoice } from '@data/types/Card';
 import DeckOption, { localizeDeckOptionError } from '@data/types/DeckOption';
@@ -44,6 +45,7 @@ import {
   THE_INSANE_CODE,
 } from '@data/deck/specialCards';
 import DeckRequirement from '@data/types/DeckRequirement';
+import {parseMetaSlots} from "@lib/parseDeck";
 
 const THE_INSANE_TAG = 'the_insane';
 
@@ -53,6 +55,7 @@ interface SpecialCardCounts {
   underworldSupport: number;
   underworldMarket: number;
   forcedLearning: number;
+  eldritchBrand: number;
 }
 
 // Code taken from:
@@ -148,7 +151,17 @@ export default class DeckValidation {
       underworldSupport: this.slots[UNDERWORLD_SUPPORT_CODE] || 0,
       underworldMarket: this.slots[UNDERWORLD_MARKET_CODE] || 0,
       forcedLearning: this.slots[FORCED_LEARNING_CODE] || 0,
+      eldritchBrand: this.slots[ELDRITCH_BRAND_CODE] || 0,
     };
+  }
+
+  eldritchBrandedCardCode(): string | undefined {
+    if (this.specialCardCounts().eldritchBrand > 0 && this.meta) {
+      const key = `attachment_${ELDRITCH_BRAND_CODE}`
+      const slots = parseMetaSlots(this.meta[key])
+      return Object.keys(slots)[0] ?? undefined;
+    }
+    return undefined;
   }
 
   deckRequirements(): DeckRequirement | undefined {
@@ -266,6 +279,16 @@ export default class DeckValidation {
             nb_copies: group.length,
             deck_limit: 1,
           };
+        }
+        if (specialCards.eldritchBrand > 0 && this.meta) {
+          const key = `attachment_${ELDRITCH_BRAND_CODE}`
+          const slots = parseMetaSlots(this.meta[key])
+          if ((slots[card.code] ?? 0) > 0) {
+            return {
+              nb_copies: group.length,
+              deck_limit: 1,
+            };
+          }
         }
         const isPreciousMemento =
           card.code === PRECIOUS_MEMENTO_FORMER_CODE ||

--- a/src/lib/parseDeck.ts
+++ b/src/lib/parseDeck.ts
@@ -368,6 +368,7 @@ function getDeckChangesHelper(
   cards: CardsMap,
   slots: Slots,
   extraDeckSize: number,
+  eldritchBrandRemoved: number,
   totalFreeCards: number,
   {
     changedCards,
@@ -554,6 +555,11 @@ function getDeckChangesHelper(
       if (extraDeckSize > 0) {
         // If your deck grew in size you can swap in extra cards for free.
         extraDeckSize--;
+        return 0;
+      }
+      if (eldritchBrandRemoved > 0) {
+        // If you removed extra copies of branded cards you can swap in new cards for free
+        eldritchBrandRemoved--;
         return 0;
       }
 
@@ -845,6 +851,10 @@ function getDeckChanges(
   ).getDeckSize(previousDeckCards);
   const invalidCards = validation.getInvalidCards(previousDeckCards);
 
+  const eldritchBrandedCardCode = validation.eldritchBrandedCardCode();
+  const eldritchBrandRemoved = eldritchBrandedCardCode && previousDeck && previousDeck.slots && deck.slots ?
+    Math.max(0, (previousDeck.slots[eldritchBrandedCardCode] ?? 0) - Math.max(1, deck.slots[eldritchBrandedCardCode] ?? 0)) :
+    0;
 
   const newDeckSize = validation.getDeckSize(newDeckCards);
   const extraDeckSize = newDeckSize - oldDeckSize;
@@ -912,6 +922,7 @@ function getDeckChanges(
     cards,
     slots,
     extraDeckSize,
+    eldritchBrandRemoved,
     totalFreeCards,
     {
       changedCards,
@@ -930,6 +941,7 @@ function getDeckChanges(
       cards,
       slots,
       extraDeckSize,
+      eldritchBrandRemoved,
       totalFreeCards,
       {
         changedCards,


### PR DESCRIPTION
The spell that is branded with Eldritch Brand should have a deck limit of 1. In addition, if a deck already contained multiple copies of that card when you add Eldritch Brand, since you are forced to remove one to comply with the new constraint, you should be able to replace that card with a level 0 card for free.