### PR TITLE
set correct size for customization header background width

### DIFF
--- a/src/components/card/CardDetailView/CardCustomizationOptions.tsx
+++ b/src/components/card/CardDetailView/CardCustomizationOptions.tsx
@@ -724,7 +724,7 @@ export default function CardCustomizationOptions({ setChoice, customizationChoic
     <View style={[{ width }, styles.container, space.paddingSideS, space.marginBottomL]}>
       <View style={{ maxWidth: MAX_WIDTH }}>
         <View style={[{ borderRadius: 8 }, backgroundStyle, shadow.large]}>
-          <RoundedFactionHeader faction={card.factionCode()} width={width - s * 2} dualFaction={!!card.faction2_code}>
+          <RoundedFactionHeader faction={card.factionCode()} width={Math.min(MAX_WIDTH, width - s * 2)} dualFaction={!!card.faction2_code}>
             <View style={[styles.row, space.marginLeftS, space.paddingTopXs]}>
               <Text style={[typography.cardName, { color: '#FFFFFF', flex: 1 }]}>
                 { t`Customizations`}

--- a/src/components/card/CardDetailView/TwoSidedCardComponent/index.tsx
+++ b/src/components/card/CardDetailView/TwoSidedCardComponent/index.tsx
@@ -468,7 +468,7 @@ export default function TwoSidedCardComponent(props: Props) {
             borderTopWidth: noHeader ? 1 : 0,
           },
         ]}>
-          { !noHeader && <CardDetailHeader card={card} width={Math.min(768, width - s * 2)} linked={!!linked} /> }
+          { !noHeader && <CardDetailHeader card={card} width={Math.min(MAX_WIDTH, width - s * 2)} linked={!!linked} /> }
           <View style={[
             styles.cardBody,
             {


### PR DESCRIPTION
ref: https://github.com/zzorba/ArkhamCards/issues/668

set the faction header width as for the cards

# android pixel
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/e8651bf8-7217-4f93-bd76-e730cba1e041" />
<img width="600" height="270" alt="image" src="https://github.com/user-attachments/assets/2f5eddfc-c398-414e-996a-f75a2d208692" />

# iphone
<img width="270" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 12 34 41" src="https://github.com/user-attachments/assets/43c089b8-f641-4a9f-841f-7581df92c301" />

# ipad
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/1c55704c-2b18-4029-b69e-a2a3429c027b" />
