### PR TITLE
fixing status bar colour

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -129,7 +129,9 @@ export default class App {
           backgroundColor: colors.background,
           style: darkMode ? 'light' : 'dark',
         },
-        android: { style: 'dark' },
+        android: {
+          style: darkMode ? 'light' : 'dark',
+        },
       }),
       topBar: {
         leftButtonColor: colors.M,

--- a/src/components/deck/DeckDetailView/index.tsx
+++ b/src/components/deck/DeckDetailView/index.tsx
@@ -395,7 +395,7 @@ function DeckDetailView({
 
       Navigation.mergeOptions(componentId, {
         statusBar: Platform.select({
-          android: { style: 'dark' },
+          android: { style: darkMode ? 'light' : 'dark' },
           ios: {
             style: statusBarStyles[mode],
             backgroundColor,
@@ -530,7 +530,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -574,7 +574,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -618,7 +618,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -676,7 +676,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -736,7 +736,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -779,7 +779,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -820,7 +820,7 @@ function DeckDetailView({
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,

--- a/src/components/deck/EditSpecialDeckCardsView.tsx
+++ b/src/components/deck/EditSpecialDeckCardsView.tsx
@@ -30,7 +30,7 @@ export interface EditSpecialCardsProps {
 }
 
 function EditSpecialDeckCardsView({ componentId, campaignId, assignedWeaknesses, id }: EditSpecialCardsProps & NavigationProps) {
-  const { backgroundStyle, colors } = useContext(StyleContext);
+  const { backgroundStyle, colors, darkMode } = useContext(StyleContext);
   const dispatch = useDispatch();
   const parsedDeckObj = useParsedDeck(id, componentId, 'edit');
   const {
@@ -82,7 +82,7 @@ function EditSpecialDeckCardsView({ componentId, campaignId, assignedWeaknesses,
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -104,7 +104,7 @@ function EditSpecialDeckCardsView({ componentId, campaignId, assignedWeaknesses,
         },
       },
     });
-  }, [componentId, factionColor, colors, id]);
+  }, [componentId, factionColor, colors, id, darkMode]);
 
   const editWeaknessPressed = useCallback(() => {
     const backgroundColor = colors.faction[factionColor].background;
@@ -117,7 +117,7 @@ function EditSpecialDeckCardsView({ componentId, campaignId, assignedWeaknesses,
         },
         options: {
           statusBar: Platform.select({
-            android: { style: 'dark' },
+            android: { style: darkMode ? 'light' : 'dark' },
             ios: {
               style: 'light',
               backgroundColor,
@@ -139,7 +139,7 @@ function EditSpecialDeckCardsView({ componentId, campaignId, assignedWeaknesses,
         },
       },
     });
-  }, [componentId, factionColor, colors, id]);
+  }, [componentId, factionColor, colors, id, darkMode]);
 
   const isSpecial = useCallback((card: Card) => {
     return !!(card.code === ACE_OF_RODS_CODE || (deckEditsRef.current && deckEditsRef.current.ignoreDeckLimitSlots[card.code] > 0));

--- a/src/components/nav/helper.tsx
+++ b/src/components/nav/helper.tsx
@@ -44,7 +44,7 @@ export function getDeckOptions(
   ].background;
   const options: Options = {
     statusBar: Platform.select({
-      android: { style: 'dark' },
+      android: { style: initialMode === 'upgrade' ? 'light' : 'dark' },
       ios: {
         style: initialMode === 'upgrade' ? 'dark' : 'light',
         backgroundColor,


### PR DESCRIPTION
setting inversed dark mode intentions seems to do the trick? pls verify @zzorba 😄 

I'm not sure if it's necessary everywhere, where I added it. seems so though.
⚠️ especially the nav/helper confuses me. I figured out how or when it's being called (e.g. investigator card -> new deck), but didn't want to go down the rabbit hole to understand the upgrade decision nor how I can get the style context into it or just the dark mode bool instead of it.

also... why is this status bar styling duplicated so freaking often? 🙈 

from my emulators:
<img width="362" height="137" alt="image" src="https://github.com/user-attachments/assets/fa856d2a-0f8d-430d-bec0-2b33fb621b5f" />
<img width="542" height="109" alt="image" src="https://github.com/user-attachments/assets/05a465fa-3ac5-4e8b-ad5e-d29cb92860d1" />
