### PR TITLE
[TSK] mark cities as revisitable when they're unlocking

### DIFF
--- a/src/data/scenario/GuidedCampaignLog.ts
+++ b/src/data/scenario/GuidedCampaignLog.ts
@@ -1723,11 +1723,16 @@ export default class GuidedCampaignLog implements GuidedCampaignLogState {
           ...this.campaignData.scarlet.unlockedLocations,
           effect.value,
         ];
+        // in case people visited a locked location before, mark it as visitable again
+        this.campaignData.scarlet.visitedLocations = filter(
+          this.campaignData.scarlet.visitedLocations,
+          (id) => id !== effect.value
+        );
         break;
       case 'hide_dossier':
         this.campaignData.scarlet.unlockedDossiers = filter(
           this.campaignData.scarlet.unlockedDossiers,
-          (x) => x !== effect.value
+          (id) => id !== effect.value
         );
         break;
       case 'unlock_dossier':


### PR DESCRIPTION
From the mythos busters discord
https://discord.com/channels/225349059689447425/909146891986563173/1419868929089605635
> Vhalantru  — 23.09.2025, 04:12
> I think we found a bug in the Scarlet Keys Campaign.
> When you get access to locations that you have already travelled through, it doesn't let you return to the location. (In this specific context it was Quito)


this should fix it, right? works for me when bouncing around south america until it unlocks at least. know a better location or is this the best approach?