### PR TITLE
fix odds calculator for generic calculations

### DIFF
--- a/src/components/chaos/OddsCalculatorComponent/index.tsx
+++ b/src/components/chaos/OddsCalculatorComponent/index.tsx
@@ -1024,7 +1024,7 @@ export default function OddsCalculatorComponent({
           return {
             token: tokenValue.token,
             value: {
-              modifier: ((xValue[tokenValue.token] || (tokenValue.counter.min || 0)) + (tokenValue.counter.adjustment || 0)) * (tokenValue.counter.scale || 1) * (tokenValue.token === 'elder_sign' ? 1 : -1),
+              modifier: ((xValue[tokenValue.token] ?? (tokenValue.counter.min || 0)) + (tokenValue.counter.adjustment || 0)) * (tokenValue.counter.scale || 1) * (tokenValue.token === 'elder_sign' ? 1 : -1),
             },
           };
         }

--- a/src/components/chaos/OddsCalculatorComponent/index.tsx
+++ b/src/components/chaos/OddsCalculatorComponent/index.tsx
@@ -1004,10 +1004,10 @@ export default function OddsCalculatorComponent({
     const tablet = find(stv, x => x.token === 'tablet');
     const elder_thing = find(stv, x => x.token === 'elder_thing');
     const initialValues = {
-      skull: (skull?.type === 'counter' && (skull.counter.initial_value || skull.counter.min)) || 0,
-      cultist: (cultist?.type === 'counter' && (cultist.counter.initial_value || cultist.counter.min)) || 0,
-      tablet: (tablet?.type === 'counter' && (tablet.counter.initial_value || tablet.counter.min)) || 0,
-      elder_thing: (elder_thing?.type === 'counter' && (elder_thing.counter.initial_value || elder_thing.counter.min)) || 0,
+      skull: (skull?.type === 'counter' && (skull.counter.initial_value ?? skull.counter.min)) || 0,
+      cultist: (cultist?.type === 'counter' && (cultist.counter.initial_value ?? cultist.counter.min)) || 0,
+      tablet: (tablet?.type === 'counter' && (tablet.counter.initial_value ?? tablet.counter.min)) || 0,
+      elder_thing: (elder_thing?.type === 'counter' && (elder_thing.counter.initial_value ?? elder_thing.counter.min)) || 0,
       elder_sign: 1,
     }
     return [
@@ -1024,7 +1024,7 @@ export default function OddsCalculatorComponent({
           return {
             token: tokenValue.token,
             value: {
-              modifier: ((xValue[tokenValue.token] ?? (tokenValue.counter.min || 0)) + (tokenValue.counter.adjustment || 0)) * (tokenValue.counter.scale || 1) * (tokenValue.token === 'elder_sign' ? 1 : -1),
+              modifier: ((xValue[tokenValue.token] ?? (tokenValue.counter.min ?? 0)) + (tokenValue.counter.adjustment ?? 0)) * (tokenValue.counter.scale ?? 1) * (tokenValue.token === 'elder_sign' ? 1 : -1),
             },
           };
         }


### PR DESCRIPTION
reported on discord: https://discord.com/channels/225349059689447425/909146891986563173/1491208144733605898

⚠️ made as PR to check whether you see other similar issues in the area? there's a couple more `||` checking on undefined and possibly having the same side effect on 0.
played around a bit with the new logic in various scenarios and campaigns. still works as expected at least in regards to modifiers (amount of cards, locations, fixed values with conditions (-2 original, -4 sometimes), auto successes (Wendys Amulet) and such.

"Generic" token calculation had a bug, where calculations for tokens set to "0"  used the wrong values (effectively the minimum of -10). When setting to 0, the `||` condition received a falsy "0" value, thinking it should use the min value => -10. Resulting in a +10 value of the token.
Happens on the generic chaos bag and Brethren of Ash at the moment, as the tokens / reference cards are not in the app.
Checking for undefined instead of the `||` condition fixes this.

previously:
<img width="344" height="417" alt="image" src="https://github.com/user-attachments/assets/21e09f61-400d-496f-a2b6-c69172457b7a" />
<img width="337" height="431" alt="image" src="https://github.com/user-attachments/assets/608b3e33-256b-42f0-a251-f473a05fbf2a" />

after:
<img width="335" height="412" alt="image" src="https://github.com/user-attachments/assets/3600fdb8-137a-4141-a964-a84c6649eb5d" />
<img width="341" height="416" alt="image" src="https://github.com/user-attachments/assets/943bac6d-d2b0-45b9-b9a4-0a4d153b0951" />
